### PR TITLE
Add pointer readme for task files

### DIFF
--- a/build/tasks/README.md
+++ b/build/tasks/README.md
@@ -1,0 +1,4 @@
+Tasks
+===
+
+Each task folder has a README.md explaining what it does, balancing for the particularities each library's API brings to the table.


### PR DESCRIPTION
Adds a readme in `build/tasks` saying how each task is documented.

> Signed-off-by: mhkeller <code@mhkeller.com>