### PR TITLE
Better rollup error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+Changelog
+===
+
+## 1.0.1
+
+> 2017-11-20
+
+Fix the Rollup on error handler.
+
+* Update rollup config to remove unnecessary check on `event.input`. Make this task more future-proof by falling back to an `other` event if we don't have a code handler.
+  * [eac5cd349b25a67aa961c2de5ae1130ad6653f07](https://github.com/bloomberg/wsk.example/commit/eac5cd349b25a67aa961c2de5ae1130ad6653f07)
+
+## 1.0.0
+
+> 2017-11-16
+
+Release!

--- a/build/tasks/rollup/events/error.js
+++ b/build/tasks/rollup/events/error.js
@@ -1,15 +1,11 @@
-var fs = require('fs');
 var notify = require('wsk').notify;
 var cleanupOutPath = require('../helpers/cleanupOutPath');
 
-// This event also fires if the file was deleted, so ignore if the file doesn't exist
 module.exports = function (event, fileConfig) {
-  if (fs.existsSync(event.input)) {
-    notify({
-      message: 'Error compiling JS...',
-      value: cleanupOutPath(event, fileConfig),
-      display: 'error',
-      error: event.error || undefined
-    });
-  }
+  notify({
+    message: 'Error compiling JS...',
+    value: cleanupOutPath(event, fileConfig),
+    display: 'error',
+    error: event.error || undefined
+  });
 };

--- a/build/tasks/rollup/onEvent.js
+++ b/build/tasks/rollup/onEvent.js
@@ -37,7 +37,8 @@ function initWatcher (watch, fileConfig) {
       rollupEvents.bundleInitial(event, fileConfig);
       watchList[fileConfig.input].firstRun = false;
     } else {
-      rollupEvents[event.code](event, fileConfig);
+      let evtHandler = rollupEvents[event.code] || rollupEvents['other'];
+      evtHandler(event, fileConfig);
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wsk.example",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A sample starter project using wsk.",
   "main": "package.json",
   "scripts": {


### PR DESCRIPTION
Update rollup config to remove unnecessary check on `event.input`. Make this task more future-proof by falling back to an `other` event if we don't have a code handler. Create a changelog. Bumps to 1.0.1.